### PR TITLE
Add information about weekly and monthly mirror

### DIFF
--- a/pacman-mirrorlist/mirrorlist
+++ b/pacman-mirrorlist/mirrorlist
@@ -12,7 +12,7 @@ Server = http://mirrors.redcorelinux.org/kaosx/$repo
 Server = http://mirror6.layerjet.com/kaos/$repo
 Server = https://mirror.alpix.eu/kaos/$repo
 
-# Canada
+# Canada - Weekly Mirror
 Server = https://ca.kaosx.cf/$repo
 
 # China
@@ -34,6 +34,8 @@ Server = https://repo.kaosx.us/$repo
 # United States
 Server = https://mirror.math.princeton.edu/pub/kaoslinux/$repo
 Server = http://mirror.dacentec.com/kaosx/$repo
+
+#United States - Monthly mirror
 Server = https://kqtos.tk/repo/$repo
 
 


### PR DESCRIPTION
This adds an explanation, about which mirror is refreshed weekly and monthly. Since the [original forum post](https://forum.kaosx.us/d/2800-april-updates-and-some-news) is silent about which of both is weekly and which is monthly, I made a guess. 

The point is obviously, to prevent switching to that mirror for e.g performance related issues and finding the system in an old state and not knowing what is going on.