### PR TITLE
argon2 build without optimizations

### DIFF
--- a/argon2/PKGBUILD
+++ b/argon2/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=argon2
 _pkgname=phc-winner-argon2
 pkgver=20190702
-pkgrel=2
+pkgrel=3
 pkgdesc='Password hash Argon2, winner of Password Hashing Competition (PHC).'
 arch=('x86_64')
 url='https://github.com/P-H-C/phc-winner-argon2'
@@ -20,18 +20,18 @@ prepare() {
 build() {
   cd ${_pkgname}-${pkgver}
 
-  make LIBRARY_REL=lib
+  make OPTTARGET='none' LIBRARY_REL=lib
 }
 
 check() {
   cd ${_pkgname}-${pkgver}
 
-  make
+  make OPTTARGET='none'
 }
 
 package() {
   cd ${_pkgname}-${pkgver}
-  make LIBRARY_REL=lib DESTDIR=${pkgdir} install
+  make OPTTARGET='none' LIBRARY_REL=lib DESTDIR=${pkgdir} install
 
   install -D -m0644 LICENSE ${pkgdir}/usr/share/licenses/argon2/LICENSE
   #install -D -m0644 libargon2.pc ${pkgdir}/usr/lib/pkgconfig/libargon2.pc


### PR DESCRIPTION
argon2 build without optimizations as the previous build caused illegal instructions on certain CPUs.